### PR TITLE
Refine bindings #2

### DIFF
--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -124,6 +124,32 @@ impl Pool {
         Ok(payout)
     }
 
+    pub fn swap_with_limit(
+        &mut self,
+        denom_in: &str,
+        denom_out: &str,
+        amount: SwapAmountWithLimit,
+    ) -> Result<SwapAmount, OsmosisError> {
+        match amount {
+            SwapAmountWithLimit::ExactIn { input, min_output } => {
+                let payout = self.swap(denom_in, denom_out, SwapAmount::In(input))?;
+                if payout.as_out() < min_output {
+                    Err(OsmosisError::PriceTooLow)
+                } else {
+                    Ok(payout)
+                }
+            }
+            SwapAmountWithLimit::ExactOut { output, max_input } => {
+                let payin = self.swap(denom_in, denom_out, SwapAmount::Out(output))?;
+                if payin.as_in() > max_input {
+                    Err(OsmosisError::PriceTooLow)
+                } else {
+                    Ok(payin)
+                }
+            }
+        }
+    }
+
     pub fn gamm_denom(&self, pool_id: u64) -> String {
         // see https://github.com/osmosis-labs/osmosis/blob/e13cddc698a121dce2f8919b2a0f6a743f4082d6/x/gamm/types/key.go#L52-L54
         format!("gamm/pool/{}", pool_id)
@@ -199,28 +225,12 @@ impl Module for OsmosisModule {
                     return Err(OsmosisError::Unimplemented.into());
                 }
                 let mut pool = POOLS.load(storage, first.pool_id)?;
+                let payout =
+                    pool.swap_with_limit(&first.denom_in, &first.denom_out, amount.clone())?;
                 let (pay_in, get_out) = match amount {
-                    SwapAmountWithLimit::ExactIn { input, min_output } => {
-                        let payout = pool
-                            .swap(&first.denom_in, &first.denom_out, SwapAmount::In(input))?
-                            .as_out();
-                        if payout < min_output {
-                            Err(OsmosisError::PriceTooLow)
-                        } else {
-                            Ok((input, payout))
-                        }
-                    }
-                    SwapAmountWithLimit::ExactOut { output, max_input } => {
-                        let payin = pool
-                            .swap(&first.denom_in, &first.denom_out, SwapAmount::Out(output))?
-                            .as_in();
-                        if payin > max_input {
-                            Err(OsmosisError::PriceTooLow)
-                        } else {
-                            Ok((payin, output))
-                        }
-                    }
-                }?;
+                    SwapAmountWithLimit::ExactIn { input, .. } => (input, payout.as_out()),
+                    SwapAmountWithLimit::ExactOut { output, .. } => (payout.as_in(), output),
+                };
                 // save updated pool state
                 POOLS.save(storage, first.pool_id, &pool)?;
 
@@ -296,7 +306,7 @@ impl Module for OsmosisModule {
                     return Err(OsmosisError::Unimplemented.into());
                 }
                 let mut pool = POOLS.load(storage, first.pool_id)?;
-                let amount = pool.swap(&first.denom_in, &first.denom_out, amount)?;
+                let amount = pool.swap_with_limit(&first.denom_in, &first.denom_out, amount)?;
                 Ok(to_binary(&EstimatePriceResponse { amount })?)
             }
         }
@@ -502,7 +512,10 @@ mod tests {
             pool_id,
             &coin_b.denom,
             &coin_a.denom,
-            SwapAmount::In(Uint128::new(501505)),
+            SwapAmountWithLimit::ExactIn {
+                input: Uint128::new(501505),
+                min_output: Uint128::zero(),
+            },
         );
         let EstimatePriceResponse { amount } = app.wrap().query(&query.into()).unwrap();
         // 6M * 1.5M = 2M * 4.5M -> output = 1.5M
@@ -514,7 +527,10 @@ mod tests {
             pool_id,
             &coin_b.denom,
             &coin_a.denom,
-            SwapAmount::Out(Uint128::new(1500000)),
+            SwapAmountWithLimit::ExactOut {
+                output: Uint128::new(1500000),
+                max_input: Uint128::MAX,
+            },
         );
         let EstimatePriceResponse { amount } = app.wrap().query(&query.into()).unwrap();
         let expected = SwapAmount::In(Uint128::new(501505));

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -21,9 +21,12 @@ pub enum OsmosisQuery {
     /// We will add TWAP for more robust price feed.
     SpotPrice { swap: Swap, with_swap_fee: bool },
     /// Return current spot price swapping In for Out on given pool ID.
+    /// You can call `EstimatePrice { contract: env.contract.address, ... }` to set sender to the
+    /// current contract.
     /// Warning: this can easily be manipulated via sandwich attacks, do not use as price oracle.
     /// We will add TWAP for more robust price feed.
     EstimatePrice {
+        contract: String,
         first: Swap,
         route: Vec<Step>,
         amount: SwapAmountWithLimit,
@@ -43,12 +46,14 @@ impl OsmosisQuery {
 
     /// Basic helper to estimate price of a swap on one pool
     pub fn estimate_price(
+        contract: impl Into<String>,
         pool_id: u64,
         denom_in: impl Into<String>,
         denom_out: impl Into<String>,
         amount: SwapAmountWithLimit,
     ) -> Self {
         OsmosisQuery::EstimatePrice {
+            contract: contract.into(),
             first: Swap::new(pool_id, denom_in, denom_out),
             amount,
             route: vec![],

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -2,7 +2,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{Step, Swap, SwapAmount};
-use crate::SwapAmountWithLimit;
 use cosmwasm_std::{Coin, CustomQuery, Decimal, Uint128};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -29,7 +28,7 @@ pub enum OsmosisQuery {
         contract: String,
         first: Swap,
         route: Vec<Step>,
-        amount: SwapAmountWithLimit,
+        amount: SwapAmount,
     },
 }
 
@@ -50,7 +49,7 @@ impl OsmosisQuery {
         pool_id: u64,
         denom_in: impl Into<String>,
         denom_out: impl Into<String>,
-        amount: SwapAmountWithLimit,
+        amount: SwapAmount,
     ) -> Self {
         OsmosisQuery::EstimatePrice {
             contract: contract.into(),

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{Step, Swap, SwapAmount};
+use crate::SwapAmountWithLimit;
 use cosmwasm_std::{Coin, CustomQuery, Decimal, Uint128};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -25,7 +26,7 @@ pub enum OsmosisQuery {
     EstimatePrice {
         first: Swap,
         route: Vec<Step>,
-        amount: SwapAmount,
+        amount: SwapAmountWithLimit,
     },
 }
 
@@ -45,7 +46,7 @@ impl OsmosisQuery {
         pool_id: u64,
         denom_in: impl Into<String>,
         denom_out: impl Into<String>,
-        amount: SwapAmount,
+        amount: SwapAmountWithLimit,
     ) -> Self {
         OsmosisQuery::EstimatePrice {
             first: Swap::new(pool_id, denom_in, denom_out),

--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -23,14 +23,14 @@ impl Swap {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Step {
     pub pool_id: u64,
-    pub denom: String,
+    pub denom_out: String,
 }
 
 impl Step {
-    pub fn new(pool_id: u64, denom: impl Into<String>) -> Self {
+    pub fn new(pool_id: u64, denom_out: impl Into<String>) -> Self {
         Step {
             pool_id,
-            denom: denom.into(),
+            denom_out: denom_out.into(),
         }
     }
 }

--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -23,14 +23,14 @@ impl Swap {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Step {
     pub pool_id: u64,
-    pub denom_out: String,
+    pub denom: String,
 }
 
 impl Step {
-    pub fn new(pool_id: u64, denom_out: impl Into<String>) -> Self {
+    pub fn new(pool_id: u64, denom: impl Into<String>) -> Self {
         Step {
             pool_id,
-            denom_out: denom_out.into(),
+            denom: denom.into(),
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/confio/osmosis/pull/4. Some changes required for implementing `EstimatePrice`:

- The multihop swap methods (https://github.com/confio/osmosis/blob/72dee1fd3b5760ca740f1125ee81fd9a06757178/x/gamm/keeper/multihop.go#L12 and https://github.com/confio/osmosis/blob/72dee1fd3b5760ca740f1125ee81fd9a06757178/x/gamm/keeper/multihop.go#L38) require a OutMin / InMax parameter. Compatible with `SwapAmountWithLimit`).
- The denom field in the `Step` struct is being used as both, `denom_out` and `denom_in`, depending on the swap type. Renaming to `denom` for generality.
- These methods also require a `sender` (contract) address. Not sure why. Not sure also if that can be obtained on the Go side, from the `Context` or so.