### PR TITLE
Multitest return swap info

### DIFF
--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -12,6 +12,7 @@ pub enum OsmosisMsg {
     /// Contracts can mint native tokens that have an auto-generated denom
     /// namespaced under the contract's address. A contract may create any number
     /// of independent sub-denoms.
+    /// Returns FullDenomResponse in the data field of the Response
     MintTokens {
         /// Must be 2-32 alphanumeric characters
         /// FIXME: revisit actual requirements in SDK
@@ -20,6 +21,7 @@ pub enum OsmosisMsg {
         recipient: String,
     },
     /// Swap over one or more pools
+    /// Returns EstimatePriceResponse in the data field of the Response
     Swap {
         first: Swap,
         route: Vec<Step>,


### PR DESCRIPTION
Closes #16 

Messages return data, using same types returned in the applicable queries. This lets the caller know what happened and take appropriate action in the reply block if desired without adding new types.

I am open to adding event attributes as well, but agree this should be the main communication format and is probably enough. The test case should demo usage.

Once this is tested in the contracts to provide all needed info, we can add it to the actual go bindings.