### PR TITLE
Swap with a route (more than one liquidity pool)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "itertools",
  "osmo-bindings",
  "schemars",
  "serde",

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://osmosis.zone"
 license = "Apache-2.0"
 
 [dependencies]
+itertools = "0.10"
 osmo-bindings = { version = "0.5.0", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -698,36 +698,33 @@ mod tests {
                 denom_out: "btc".to_string(),
             }],
             amount: SwapAmountWithLimit::ExactIn {
-                input: Uint128::new(4028),
+                input: Uint128::new(4000),
                 min_output: Uint128::new(900),
             },
         };
         let res = app.execute(trader.clone(), msg.into()).unwrap();
 
         let Coin { amount, .. } = app.wrap().query_balance(&trader, "osmo").unwrap();
-        assert_eq!(amount, Uint128::new(5000 - 4028));
+        assert_eq!(amount, Uint128::new(5000 - 4000));
         let Coin { amount, .. } = app.wrap().query_balance(&trader, "btc").unwrap();
-        assert_eq!(amount, Uint128::new(1000));
+        assert_eq!(amount, Uint128::new(993));
 
         // check the response contains proper value
         let input: EstimatePriceResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
-        assert_eq!(input.amount, SwapAmount::Out(Uint128::new(1000)));
+        assert_eq!(input.amount, SwapAmount::Out(Uint128::new(993)));
 
         // check pool state properly updated with fees
         let query = OsmosisQuery::PoolState { id: 1 }.into();
         let state: PoolStateResponse = app.wrap().query(&query).unwrap();
         let expected_assets = vec![
-            coin(6_000_000 + 4028, "osmo"),
-            coin(3_000_000 - 2007, "atom"),
+            coin(6_000_000 + 4000, "osmo"),
+            coin(3_000_000 - 1993, "atom"),
         ];
         assert_eq!(state.assets, expected_assets);
 
         let query = OsmosisQuery::PoolState { id: 2 }.into();
         let state: PoolStateResponse = app.wrap().query(&query).unwrap();
-        let expected_assets = vec![
-            coin(2_000_000 + 2007, "atom"),
-            coin(1_000_000 - 1000, "btc"),
-        ];
+        let expected_assets = vec![coin(2_000_000 + 1993, "atom"), coin(1_000_000 - 993, "btc")];
         assert_eq!(state.assets, expected_assets);
     }
 

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -608,6 +608,82 @@ mod tests {
     }
 
     #[test]
+    fn swap_with_route_max_input_exceeded() {
+        let pool1 = Pool::new(coin(6_000_000, "osmo"), coin(3_000_000, "atom"));
+        let pool2 = Pool::new(coin(2_000_000, "atom"), coin(1_000_000, "btc"));
+        let trader = Addr::unchecked("trader");
+
+        let mut app = OsmosisApp::new();
+        app.init_modules(|router, _, storage| {
+            router.custom.set_pool(storage, 1, &pool1).unwrap();
+            router.custom.set_pool(storage, 2, &pool2).unwrap();
+            router
+                .bank
+                .init_balance(storage, &trader, coins(5000, "osmo"))
+                .unwrap()
+        });
+
+        let msg = OsmosisMsg::Swap {
+            first: Swap {
+                pool_id: 1,
+                denom_in: "osmo".to_string(),
+                denom_out: "atom".to_string(),
+            },
+            route: vec![Step {
+                pool_id: 2,
+                denom_out: "btc".to_string(),
+            }],
+            amount: SwapAmountWithLimit::ExactOut {
+                output: Uint128::new(1000),
+                max_input: Uint128::new(4000),
+            },
+        };
+        let err = app.execute(trader, msg.into()).unwrap_err();
+        assert_eq!(
+            err.downcast::<OsmosisError>().unwrap(),
+            OsmosisError::PriceTooLow
+        );
+    }
+
+    #[test]
+    fn swap_with_route_min_output_not_met() {
+        let pool1 = Pool::new(coin(6_000_000, "osmo"), coin(3_000_000, "atom"));
+        let pool2 = Pool::new(coin(2_000_000, "atom"), coin(1_000_000, "btc"));
+        let trader = Addr::unchecked("trader");
+
+        let mut app = OsmosisApp::new();
+        app.init_modules(|router, _, storage| {
+            router.custom.set_pool(storage, 1, &pool1).unwrap();
+            router.custom.set_pool(storage, 2, &pool2).unwrap();
+            router
+                .bank
+                .init_balance(storage, &trader, coins(5000, "osmo"))
+                .unwrap()
+        });
+
+        let msg = OsmosisMsg::Swap {
+            first: Swap {
+                pool_id: 1,
+                denom_in: "osmo".to_string(),
+                denom_out: "atom".to_string(),
+            },
+            route: vec![Step {
+                pool_id: 2,
+                denom_out: "btc".to_string(),
+            }],
+            amount: SwapAmountWithLimit::ExactIn {
+                input: Uint128::new(4000),
+                min_output: Uint128::new(1000),
+            },
+        };
+        let err = app.execute(trader, msg.into()).unwrap_err();
+        assert_eq!(
+            err.downcast::<OsmosisError>().unwrap(),
+            OsmosisError::PriceTooLow
+        );
+    }
+
+    #[test]
     fn perform_swap_with_route_exact_out() {
         let pool1 = Pool::new(coin(6_000_000, "osmo"), coin(3_000_000, "atom"));
         let pool2 = Pool::new(coin(2_000_000, "atom"), coin(1_000_000, "btc"));
@@ -624,7 +700,6 @@ mod tests {
                 .unwrap()
         });
 
-        // now a proper swap
         let msg = OsmosisMsg::Swap {
             first: Swap {
                 pool_id: 1,

--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -64,3 +64,12 @@ pub enum SwapAmountWithLimit {
     ExactIn { input: Uint128, min_output: Uint128 },
     ExactOut { output: Uint128, max_input: Uint128 },
 }
+
+impl SwapAmountWithLimit {
+    pub fn discard_limit(self) -> SwapAmount {
+        match self {
+            SwapAmountWithLimit::ExactIn { input, .. } => SwapAmount::In(input),
+            SwapAmountWithLimit::ExactOut { output, .. } => SwapAmount::Out(output),
+        }
+    }
+}


### PR DESCRIPTION
Closes #19 

Swaps can now have a route and still be tested with `bindings-test`!