### PR TITLE
v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "osmo-bindings"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "osmo-bindings-test"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "osmo-reflect"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmo-reflect"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Reflect messages to use for test cases - based on cw-mask"
@@ -19,7 +19,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta6", features = ["staking", "stargate"] }
 cosmwasm-storage = "1.0.0-beta6"
-osmo-bindings = { version = "0.5.0", path = "../../packages/bindings" }
+osmo-bindings = { version = "0.5.1", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0"

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmo-bindings-test"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Osmosis-specific contracts"
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 itertools = "0.10"
-osmo-bindings = { version = "0.5.0", path = "../bindings" }
+osmo-bindings = { version = "0.5.1", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmo-bindings"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Osmosis blockchain"


### PR DESCRIPTION
This only includes the routed swap implementation (#20) and doesn't break any APIs, hence patch version bump.