### PR TITLE
Rename EstimatePriceResponse to SwapResponse for consistency / clarity

### DIFF
--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -20,8 +20,8 @@ use cw_multi_test::{
 use cw_storage_plus::Map;
 
 use osmo_bindings::{
-    EstimatePriceResponse, FullDenomResponse, OsmosisMsg, OsmosisQuery, PoolStateResponse,
-    SpotPriceResponse, Step, Swap, SwapAmount, SwapAmountWithLimit,
+    FullDenomResponse, OsmosisMsg, OsmosisQuery, PoolStateResponse, SpotPriceResponse, Step, Swap,
+    SwapAmount, SwapAmountWithLimit, SwapResponse,
 };
 
 pub const POOLS: Map<u64, Pool> = Map::new("pools");
@@ -327,7 +327,7 @@ impl Module for OsmosisModule {
                     SwapAmountWithLimit::ExactIn { .. } => SwapAmount::Out(get_out),
                     SwapAmountWithLimit::ExactOut { .. } => SwapAmount::In(pay_in),
                 };
-                let data = Some(to_binary(&EstimatePriceResponse { amount: output })?);
+                let data = Some(to_binary(&SwapResponse { amount: output })?);
                 Ok(AppResponse {
                     data,
                     events: vec![],
@@ -390,7 +390,7 @@ impl Module for OsmosisModule {
             } => {
                 let (amount, _) = complex_swap(storage, first, route, amount)?;
 
-                Ok(to_binary(&EstimatePriceResponse { amount })?)
+                Ok(to_binary(&SwapResponse { amount })?)
             }
         }
     }
@@ -592,27 +592,27 @@ mod tests {
         });
 
         // estimate the price (501505 * 0.997 = 500_000) after fees gone
-        let query = OsmosisQuery::estimate_price(
+        let query = OsmosisQuery::estimate_swap(
             MOCK_CONTRACT_ADDR,
             pool_id,
             &coin_b.denom,
             &coin_a.denom,
             SwapAmount::In(Uint128::new(501505)),
         );
-        let EstimatePriceResponse { amount } = app.wrap().query(&query.into()).unwrap();
+        let SwapResponse { amount } = app.wrap().query(&query.into()).unwrap();
         // 6M * 1.5M = 2M * 4.5M -> output = 1.5M
         let expected = SwapAmount::Out(Uint128::new(1_500_000));
         assert_eq!(amount, expected);
 
         // now try the reverse query. we know what we need to pay to get 1.5M out
-        let query = OsmosisQuery::estimate_price(
+        let query = OsmosisQuery::estimate_swap(
             MOCK_CONTRACT_ADDR,
             pool_id,
             &coin_b.denom,
             &coin_a.denom,
             SwapAmount::Out(Uint128::new(1500000)),
         );
-        let EstimatePriceResponse { amount } = app.wrap().query(&query.into()).unwrap();
+        let SwapResponse { amount } = app.wrap().query(&query.into()).unwrap();
         let expected = SwapAmount::In(Uint128::new(501505));
         assert_eq!(amount, expected);
     }
@@ -673,7 +673,7 @@ mod tests {
         assert_eq!(amount, Uint128::new(298_495));
 
         // check the response contains proper value
-        let input: EstimatePriceResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
+        let input: SwapResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
         assert_eq!(input.amount, SwapAmount::In(Uint128::new(501_505)));
 
         // check pool state properly updated with fees
@@ -840,7 +840,7 @@ mod tests {
         assert_eq!(amount, Uint128::new(1000));
 
         // check the response contains proper value
-        let input: EstimatePriceResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
+        let input: SwapResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
         assert_eq!(input.amount, SwapAmount::In(Uint128::new(4033)));
 
         // check pool state properly updated with fees
@@ -902,7 +902,7 @@ mod tests {
         assert_eq!(amount, Uint128::new(993));
 
         // check the response contains proper value
-        let input: EstimatePriceResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
+        let input: SwapResponse = from_slice(res.data.unwrap().as_slice()).unwrap();
         assert_eq!(input.amount, SwapAmount::Out(Uint128::new(993)));
 
         // check pool state properly updated with fees
@@ -933,27 +933,27 @@ mod tests {
         });
 
         // estimate the price (501505 * 0.997 = 500_000) after fees gone
-        let query = OsmosisQuery::estimate_price(
+        let query = OsmosisQuery::estimate_swap(
             MOCK_CONTRACT_ADDR,
             1,
             "atom",
             "btc",
             SwapAmount::In(Uint128::new(2007)),
         );
-        let EstimatePriceResponse { amount } = app.wrap().query(&query.into()).unwrap();
+        let SwapResponse { amount } = app.wrap().query(&query.into()).unwrap();
         // 6M * 1.5M = 2M * 4.5M -> output = 1.5M
         let expected = SwapAmount::Out(Uint128::new(1000));
         assert_eq!(amount, expected);
 
         // now try the reverse query. we know what we need to pay to get 1.5M out
-        let query = OsmosisQuery::estimate_price(
+        let query = OsmosisQuery::estimate_swap(
             MOCK_CONTRACT_ADDR,
             1,
             "atom",
             "btc",
             SwapAmount::Out(Uint128::new(1000)),
         );
-        let EstimatePriceResponse { amount } = app.wrap().query(&query.into()).unwrap();
+        let SwapResponse { amount } = app.wrap().query(&query.into()).unwrap();
         let expected = SwapAmount::In(Uint128::new(2007));
         assert_eq!(amount, expected);
     }

--- a/packages/bindings/Research.md
+++ b/packages/bindings/Research.md
@@ -121,7 +121,7 @@ Should that be:
 * Input + N (pool + output) Where N >= 1 is enforced runtime?
 * Define first swap and then an optional list of chains? (type safety that we cannot add N == 0)
 
-**Note**: The first element is currently being enforced at the structs level. See [EstimatePrice](./src/query.rs)
+**Note**: The first element is currently being enforced at the structs level. See [EstimateSwap](./src/query.rs)
 and [Swap](./src/msg.rs).
 
 ### To be defined

--- a/packages/bindings/examples/schema.rs
+++ b/packages/bindings/examples/schema.rs
@@ -4,8 +4,7 @@ use std::fs::create_dir_all;
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 use osmo_bindings::{
-    EstimatePriceResponse, FullDenomResponse, OsmosisMsg, OsmosisQuery, PoolStateResponse,
-    SpotPriceResponse,
+    FullDenomResponse, OsmosisMsg, OsmosisQuery, PoolStateResponse, SpotPriceResponse, SwapResponse,
 };
 
 fn main() {
@@ -19,5 +18,5 @@ fn main() {
     export_schema(&schema_for!(FullDenomResponse), &out_dir);
     export_schema(&schema_for!(PoolStateResponse), &out_dir);
     export_schema(&schema_for!(SpotPriceResponse), &out_dir);
-    export_schema(&schema_for!(EstimatePriceResponse), &out_dir);
+    export_schema(&schema_for!(SwapResponse), &out_dir);
 }

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -4,7 +4,7 @@ mod types;
 
 pub use msg::OsmosisMsg;
 pub use query::{
-    EstimatePriceResponse, FullDenomResponse, OsmosisQuery, PoolStateResponse, SpotPriceResponse,
+    FullDenomResponse, OsmosisQuery, PoolStateResponse, SpotPriceResponse, SwapResponse,
 };
 pub use types::{Step, Swap, SwapAmount, SwapAmountWithLimit};
 

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -21,7 +21,7 @@ pub enum OsmosisMsg {
         recipient: String,
     },
     /// Swap over one or more pools
-    /// Returns EstimatePriceResponse in the data field of the Response
+    /// Returns SwapResponse in the data field of the Response
     Swap {
         first: Swap,
         route: Vec<Step>,

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -44,7 +44,7 @@ impl OsmosisQuery {
     }
 
     /// Basic helper to estimate price of a swap on one pool
-    pub fn estimate_price(
+    pub fn estimate_swap(
         contract: impl Into<String>,
         pool_id: u64,
         denom_in: impl Into<String>,
@@ -102,7 +102,7 @@ pub struct SpotPriceResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct EstimatePriceResponse {
+pub struct SwapResponse {
     // If you query with SwapAmount::Input, this is SwapAmount::Output
     // If you query with SwapAmount::Output, this is SwapAmount::Input
     pub amount: SwapAmount,


### PR DESCRIPTION
Just a delta on top of #25. Done in a different MR for clarity. Turns out this doesn't exports any bindings, because the rename is of an ancillary struct. So, these changes are in fact independent of the Osmosis repo.